### PR TITLE
fix: skipped entities

### DIFF
--- a/docsmith.py
+++ b/docsmith.py
@@ -138,8 +138,8 @@ class DocstringTransformer(cst.CSTTransformer):
         self._current_class = node.name.value
 
         if (
-            self.changed_entities is not None
-            and node.name.value in self.changed_entities.classes
+            self.changed_entities is None
+            or node.name.value in self.changed_entities.classes
         ):
             source_lines = cst.Module([node]).code
             template = extract_signatures(self.module, node)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-docsmith"
-version = "0.2"
+version = "0.2.1"
 description = "Generate Python docstrings automatically with LLM and syntax trees."
 readme = "README.md"
 authors = [{name = "Matheus Pedroni"}]

--- a/tests/test_docsmith.py
+++ b/tests/test_docsmith.py
@@ -1,12 +1,14 @@
 import textwrap
 from unittest.mock import Mock, patch
 
+import libcst as cst
 import pytest
 
 from docsmith import (
     Argument,
     ChangedEntities,
     Docstring,
+    DocstringTransformer,
     Documentation,
     Return,
     docstring_to_str,
@@ -262,6 +264,104 @@ def test_extract_signatures_private_methods():
     # Should only include public methods
     assert len(doc.entries) == 2  # Test class + public method
     assert all(not entry.name.startswith("_") for entry in doc.entries)
+
+
+def test_docstring_transformer_without_changed_entities():
+    source = textwrap.dedent("""
+    def greet():
+        return "hello"
+
+    class MyClass:
+        def my_method(self):
+            pass
+    """)
+
+    def mock_generator(input_code, context, template):
+        return Documentation(
+            entries=[
+                Docstring(
+                    node_type="function", name="greet", docstring="A test function."
+                ),
+                Docstring(node_type="class", name="MyClass", docstring="A test class."),
+                Docstring(
+                    node_type="function", name="my_method", docstring="A test method."
+                ),
+            ]
+        )
+
+    module = cst.parse_module(source)
+    transformer = DocstringTransformer(mock_generator, module)
+    modified = module.visit(transformer)
+
+    assert "A test function." in modified.code
+    assert "A test class." in modified.code
+    assert "A test method." in modified.code
+
+
+def test_docstring_transformer_with_changed_entities():
+    source = textwrap.dedent("""
+    def changed_function():
+        return True
+
+    def unchanged_function():
+        return False
+
+    class ChangedClass:
+        def changed_method(self):
+            pass
+
+        def unchanged_method(self):
+            pass
+
+    class UnchangedClass:
+        def another_method(self):
+            pass
+    """)
+
+    def mock_generator(input_code, context, template):
+        return Documentation(
+            entries=[
+                Docstring(
+                    node_type="function",
+                    name="changed_function",
+                    docstring="A changed function.",
+                ),
+                Docstring(
+                    node_type="function",
+                    name="unchanged_function",
+                    docstring="An unchanged function.",
+                ),
+                Docstring(
+                    node_type="class", name="ChangedClass", docstring="A changed class."
+                ),
+                Docstring(
+                    node_type="function",
+                    name="changed_method",
+                    docstring="A changed method.",
+                ),
+                Docstring(
+                    node_type="function",
+                    name="unchanged_method",
+                    docstring="An unchanged method.",
+                ),
+            ]
+        )
+
+    changed_entities = ChangedEntities(
+        functions={"changed_function"},
+        classes={"ChangedClass"},
+        methods={"ChangedClass.changed_method"},
+    )
+
+    module = cst.parse_module(source)
+    transformer = DocstringTransformer(mock_generator, module, changed_entities)
+    modified = module.code_for_node(module.visit(transformer))
+
+    assert "A changed function." in modified
+    assert "A changed class." in modified
+    assert "A changed method." in modified
+    assert "An unchanged function." not in modified
+    assert "An unchanged method." not in modified
 
 
 @patch("subprocess.run")


### PR DESCRIPTION
Some classes and methods were skipped when not using the `--git` option after #7.
The logic was fixed and test cases were added to prevent regression.